### PR TITLE
Fix: make cache key dynamic

### DIFF
--- a/src/Services/OAuthService.php
+++ b/src/Services/OAuthService.php
@@ -49,6 +49,7 @@ class OAuthService
     {
         $retryCount = 0;
 
+        /** @phpstan-ignore-next-line */
         $cacheName = self::CACHE_NAME . '_' . hash('sha256', $this->config->getCredentials(true));
 
         while ($retryCount < self::RETRY_LIMIT) {


### PR DESCRIPTION
stops failure when credentials change

We attempt to decrypt the token that was encrypted using old credentials with the new ones.