### PR TITLE
fix: Allow dynamic properties and do not trigger deprecated errors for PHP versions 8.2 and above

### DIFF
--- a/src/Constants/SdkConstants.php
+++ b/src/Constants/SdkConstants.php
@@ -4,7 +4,7 @@ namespace Airalo\Constants;
 
 final class SdkConstants
 {
-    public const VERSION = '1.1.13';
+    public const VERSION = '1.1.14';
 
     public const BULK_ORDER_LIMIT = 50;
 

--- a/src/Helpers/EasyAccess.php
+++ b/src/Helpers/EasyAccess.php
@@ -7,6 +7,7 @@ error_reporting(E_ALL ^ (E_DEPRECATED));
 
 use Airalo\Exceptions\AiraloException;
 
+#[\AllowDynamicProperties]
 class EasyAccess implements \ArrayAccess, \Countable
 {
     private const STRING_KEY = "stringData";


### PR DESCRIPTION
As this class was intended to be used with dynamic properties, we should annotate the class accordingly, to avoid spawning deprecated errors about assigning properties dynamically, which is not supported anymore since PHP 8.2