### PR TITLE
feat: Add locale to get locale packages (AP-6529)

### DIFF
--- a/src/Airalo.php
+++ b/src/Airalo.php
@@ -73,7 +73,7 @@ class Airalo
      * @param mixed $page
      * @return EasyAccess|null
      */
-    public function getAllPackages(bool $flat = false, $limit = null, $page = null, $locale = 'en'): ?EasyAccess
+    public function getAllPackages(bool $flat = false, $limit = null, $page = null, string $locale = 'en'): ?EasyAccess
     {
         return $this->packages->getPackages([
             'flat' => $flat,

--- a/src/Airalo.php
+++ b/src/Airalo.php
@@ -73,13 +73,13 @@ class Airalo
      * @param mixed $page
      * @return EasyAccess|null
      */
-    public function getAllPackages(bool $flat = false, $limit = null, $page = null): ?EasyAccess
+    public function getAllPackages(bool $flat = false, $limit = null, $page = null, $locale = 'en'): ?EasyAccess
     {
         return $this->packages->getPackages([
             'flat' => $flat,
             'limit' => $limit,
             'page' => $page,
-        ]);
+        ], $locale);
     }
 
     public function getSimPackages(bool $flat = false, $limit = null, $page = null): ?EasyAccess

--- a/src/AiraloStatic.php
+++ b/src/AiraloStatic.php
@@ -70,7 +70,7 @@ class AiraloStatic
      * @param mixed $page
      * @return EasyAccess|null
      */
-    public static function getAllPackages(bool $flat = false, $limit = null, $page = null): ?EasyAccess
+    public static function getAllPackages(bool $flat = false, $limit = null, $page = null, $locale = 'en'): ?EasyAccess
     {
         self::checkInitialized();
 
@@ -78,7 +78,7 @@ class AiraloStatic
             'flat' => $flat,
             'limit' => $limit,
             'page' => $page,
-        ]);
+        ], $locale);
     }
 
     public static function getSimPackages(bool $flat = false, $limit = null, $page = null): ?EasyAccess

--- a/src/AiraloStatic.php
+++ b/src/AiraloStatic.php
@@ -70,7 +70,7 @@ class AiraloStatic
      * @param mixed $page
      * @return EasyAccess|null
      */
-    public static function getAllPackages(bool $flat = false, $limit = null, $page = null, $locale = 'en'): ?EasyAccess
+    public static function getAllPackages(bool $flat = false, $limit = null, $page = null, string $locale = 'en'): ?EasyAccess
     {
         self::checkInitialized();
 

--- a/src/Constants/SdkConstants.php
+++ b/src/Constants/SdkConstants.php
@@ -4,7 +4,7 @@ namespace Airalo\Constants;
 
 final class SdkConstants
 {
-    public const VERSION = '1.1.16';
+    public const VERSION = '1.1.18';
 
     public const BULK_ORDER_LIMIT = 50;
 

--- a/src/Services/PackagesService.php
+++ b/src/Services/PackagesService.php
@@ -42,11 +42,11 @@ class PackagesService
      * @param array $params
      * @return EasyAccess|null
      */
-    public function getPackages(array $params = []): ?EasyAccess
+    public function getPackages(array $params = [], $locale): ?EasyAccess
     {
         $url = $this->buildUrl($params);
 
-        $result = Cached::get(function () use ($url, $params) {
+        $result = Cached::get(function () use ($url, $params, $locale) {
             $currentPage = $params['page'] ?? 1;
             $result = ['data' => []];
 
@@ -58,6 +58,7 @@ class PackagesService
                 $response = $this->curl->setHeaders([
                     'Content-Type: application/json',
                     'Authorization: Bearer ' . $this->accessToken,
+                    'Accept-Language: ' . $locale,
                 ])->get($pageUrl ?? $url);
 
                 if (!$response) {

--- a/src/Services/PackagesService.php
+++ b/src/Services/PackagesService.php
@@ -42,7 +42,7 @@ class PackagesService
      * @param array $params
      * @return EasyAccess|null
      */
-    public function getPackages(array $params = [], $locale): ?EasyAccess
+    public function getPackages(array $params = [], string $locale = 'en'): ?EasyAccess
     {
         $url = $this->buildUrl($params);
 


### PR DESCRIPTION
This PR updates the getAllPackages method to pass the Accept-Language parameter in the API call header. This allows the method to handle different locales dynamically. The default locale is set to English (en).