### PR TITLE
feat: [BE] Support country filter on the get top-ups endpoint to filter out top-ups for the universal sim "GET/v2/sims/:iccid/topups" in SDK (AP-7797)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ Fetching global Airalo packages. By default the response will be the same as the
 By default no limit number of packages will be applied if `$limit` is empty<br>
 By default it will paginate all pages (multiple calls) or if `$page` is provided it will be the starting pagination index.<br>
 
+`public function getUniversalPackages(bool $flat = false, ?int $limit = null, ?int $page = null): ?EasyAccess`<br>
+Fetching universal Airalo packages. By default the response will be the same as the one from packages REST endpoint (more here: https://developers.partners.airalo.com/get-packages-11883036e0). Passing `$flat` as true will return package objects data in a single data object.<br>
+By default no limit number of packages will be applied if `$limit` is empty<br>
+By default it will paginate all pages (multiple calls) or if `$page` is provided it will be the starting pagination index.<br>
 
 `public function getCountryPackages(string $countryCode, bool $flat = false, $limit = null): ?EasyAccess`<br>
 Fetching country specific Airalo packages. By default the response will be the same as the one from packages REST endpoint (more here: https://developers.partners.airalo.com/get-packages-11883036e0). Passing `$flat` as true will return package objects data in a single data object.<br>
@@ -992,9 +996,13 @@ Example response can be found in the API documentation (link above). <br>
 <br><br>
 <h2> Sim Topups </h2>
 
-`public function getSimTopups(string $iccid): ?EasyAccess`<br>
+`public function getSimTopups(string $iccid, ?string $iso2CountryCode = null): ?EasyAccess`<br>
 
 Fetches all available topups for the provided `iccid` belonging to an ordered eSIM. <br>
+
+`$iccid` - the `iccid` from the eSim order<br>
+`$iso2CountryCode` - optional parameter to filter topups for a specific iso2 country code. Only applicable if the `iccid` is from a universal eSim<br>
+
 Full response example can be found here: https://developers.partners.airalo.com/get-top-up-package-list-11883031e0<br>
 
 ```php

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ By default it will paginate all pages (multiple calls) or if `$page` is provided
 Fetching universal Airalo packages. By default the response will be the same as the one from packages REST endpoint (more here: https://developers.partners.airalo.com/get-packages-11883036e0). Passing `$flat` as true will return package objects data in a single data object.<br>
 By default no limit number of packages will be applied if `$limit` is empty<br>
 By default it will paginate all pages (multiple calls) or if `$page` is provided it will be the starting pagination index.<br>
+Note: This method will return no results unless Universal Packages are enabled for your account by your Account Manager.
 
 `public function getCountryPackages(string $countryCode, bool $flat = false, $limit = null): ?EasyAccess`<br>
 Fetching country specific Airalo packages. By default the response will be the same as the one from packages REST endpoint (more here: https://developers.partners.airalo.com/get-packages-11883036e0). Passing `$flat` as true will return package objects data in a single data object.<br>

--- a/src/Airalo.php
+++ b/src/Airalo.php
@@ -126,6 +126,22 @@ class Airalo
     }
 
     /**
+     * @param bool $flat
+     * @param $limit
+     * @param $page
+     * @return EasyAccess|null
+     */
+    public function getUniversalPackages(bool $flat = false, ?int $limit = null, ?int $page = null): ?EasyAccess
+    {
+        return $this->packages->getPackages([
+            'flat' => $flat,
+            'limit' => $limit,
+            'page' => $page,
+            'type' => 'universal',
+        ]);
+    }
+
+    /**
      * @param string $countryCode
      * @param bool $flat
      * @param mixed $limit
@@ -320,10 +336,11 @@ class Airalo
      * @param string $iccid
      * @return EasyAccess|null
      */
-    public function getSimTopups(string $iccid): ?EasyAccess
+    public function getSimTopups(string $iccid, ?string $iso2CountryCode = null): ?EasyAccess
     {
         return $this->sim->simTopups([
-            'iccid' => $iccid
+            'iccid' => $iccid,
+            'filter[country]' => $iso2CountryCode,
         ]);
     }
 

--- a/src/Airalo.php
+++ b/src/Airalo.php
@@ -127,8 +127,8 @@ class Airalo
 
     /**
      * @param bool $flat
-     * @param $limit
-     * @param $page
+     * @param int|null $limit
+     * @param int|null $page
      * @return EasyAccess|null
      */
     public function getUniversalPackages(bool $flat = false, ?int $limit = null, ?int $page = null): ?EasyAccess
@@ -334,6 +334,7 @@ class Airalo
 
     /**
      * @param string $iccid
+     * @param string|null $iso2CountryCode
      * @return EasyAccess|null
      */
     public function getSimTopups(string $iccid, ?string $iso2CountryCode = null): ?EasyAccess

--- a/src/AiraloStatic.php
+++ b/src/AiraloStatic.php
@@ -132,6 +132,25 @@ class AiraloStatic
     }
 
     /**
+     * @param bool $flat
+     * @param $limit
+     * @param $page
+     * @return EasyAccess|null
+     * @throws AiraloException
+     */
+    public static function getUniversalPackages(bool $flat = false, ?int $limit = null, ?int $page = null): ?EasyAccess
+    {
+        self::checkInitialized();
+
+        return self::$packages->getPackages([
+            'flat' => $flat,
+            'limit' => $limit,
+            'page' => $page,
+            'type' => 'universal',
+        ]);
+    }
+
+    /**
      * @param string $countryCode
      * @param bool $flat
      * @param mixed $limit
@@ -348,10 +367,11 @@ class AiraloStatic
      * @param string $iccid
      * @return EasyAccess|null
      */
-    public static function getSimTopups(string $iccid): ?EasyAccess
+    public static function getSimTopups(string $iccid, ?string $iso2CountryCode = null): ?EasyAccess
     {
         return self::$sim->simTopups([
-            'iccid' => $iccid
+            'iccid' => $iccid,
+            'filter[country]' => $iso2CountryCode,
         ]);
     }
 

--- a/src/AiraloStatic.php
+++ b/src/AiraloStatic.php
@@ -133,8 +133,8 @@ class AiraloStatic
 
     /**
      * @param bool $flat
-     * @param $limit
-     * @param $page
+     * @param int|null $limit
+     * @param int|null $page
      * @return EasyAccess|null
      * @throws AiraloException
      */
@@ -365,6 +365,7 @@ class AiraloStatic
 
     /**
      * @param string $iccid
+     * @param string|null $iso2CountryCode
      * @return EasyAccess|null
      */
     public static function getSimTopups(string $iccid, ?string $iso2CountryCode = null): ?EasyAccess

--- a/src/Services/PackagesService.php
+++ b/src/Services/PackagesService.php
@@ -115,6 +115,9 @@ class PackagesService
         if (isset($params['type']) && $params['type'] == 'global') {
             $queryParams['filter[type]'] = 'global';
         }
+        if (isset($params['type']) && $params['type'] == 'universal') {
+            $queryParams['filter[type]'] = 'universal';
+        }
         if (isset($params['country'])) {
             $queryParams['filter[country]'] = $params['country'];
         }

--- a/src/Services/SimService.php
+++ b/src/Services/SimService.php
@@ -162,6 +162,10 @@ class SimService
         /* @phpstan-ignore-next-line */
         $iccid = (string) $params['iccid'];
 
+        if($slug === ApiConstants::SIMS_TOPUPS && !empty($params['filter[country]'])) {
+            $slug .= '?'.http_build_query(['filter[country]' => $params['filter[country]']]);
+        }
+
         return sprintf(
             '%s%s/%s/%s',
             $this->baseUrl,

--- a/tests/AiraloTest.php
+++ b/tests/AiraloTest.php
@@ -124,6 +124,19 @@ class AiraloTest extends TestCase
         $this->assertSame($expectedResult, $result);
     }
 
+    public function testGetUniversalPackages()
+    {
+        $expectedResult = $this->createMock(EasyAccess::class);
+        $this->packagesServiceMock
+            ->expects($this->once())
+            ->method('getPackages')
+            ->with(['flat' => false, 'limit' => null, 'page' => null, 'type' => 'universal'])
+            ->willReturn($expectedResult);
+
+        $result = $this->airalo->getUniversalPackages();
+        $this->assertSame($expectedResult, $result);
+    }
+
     public function testGetCountryPackages()
     {
         $expectedResult = $this->createMock(EasyAccess::class);


### PR DESCRIPTION
Support country filter on the get top-ups endpoint to filter out top-ups for the universal sim "GET/v2/sims/:iccid/topups" in SDK (AP-7797)